### PR TITLE
🎉 同步BuffInfo表键与一代一致

### DIFF
--- a/nonebot_plugin_xiuxian_2/xiuxian/xiuxian2_handle.py
+++ b/nonebot_plugin_xiuxian_2/xiuxian/xiuxian2_handle.py
@@ -27,7 +27,7 @@ SectInfo = namedtuple("SectInfo",
                        "sect_materials", "mainbuff", "secbuff", "elixir_room_level"])
 BuffInfo = namedtuple("BuffInfo",
                       ["id", "user_id", "main_buff", "sec_buff", "faqi_buff", "fabao_weapon", "armor_buff", "atk_buff",
-                       "blessed_spot"])
+                       "blessed_spot", "sub_buff"])
 back = namedtuple("back", ["user_id", "goods_id", "goods_name", "goods_type", "goods_num", "create_time", "update_time",
                            "remake", "day_num", "all_num", "action_time", "state", "bind_num"])
 


### PR DESCRIPTION
使得继承一代数据，不再无法显示个人信息